### PR TITLE
Fix compilation warnings about int64_t format argument.

### DIFF
--- a/src/numberformat.c
+++ b/src/numberformat.c
@@ -238,7 +238,7 @@ char *numberformat_space_64 (int64_t n, const char *sep)
     char in[30];
     ret = malloc (40);
     ret[0] = 0;
-    sprintf (in, "%ld", n);
+    sprintf (in, "%lld", n);
     int lin = strlen (in);
 
     int before = (lin % 3);

--- a/src/props.c
+++ b/src/props.c
@@ -242,7 +242,7 @@ void props_put_int64 (Props *self, const char *name, int64_t value)
   LOG_IN
   log_debug ("props_put_integer: key=%s, value=%ld", name, value);
   char s[30];
-  snprintf (s, sizeof (s), "%ld", value);
+  snprintf (s, sizeof (s), "%lld", value);
   props_put (self, name, s);
   LOG_OUT
   }


### PR DESCRIPTION
On Linux 5.10.11-v7+ with gcc 8.3.0 (Raspbian 8.3.0-6+rpi1) you get the following warnings with the original code:

src/props.c: In function 'props_put_int64':
src/props.c:245:31: warning: format '%ld' expects argument of type 'long int', but argument 4 has type 'int64_t' {aka 'long long int'} [-Wformat=]

src/numberformat.c: In function 'numberformat_space_64':
src/numberformat.c:241:21: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'int64_t' {aka 'long long int'} [-Wformat=]